### PR TITLE
Updated docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,22 @@
 version: '3.9'
 
 services:
-  django-app:
+  warehouse-service:
     build: .
-    container_name: django_app
+    container_name: warehouse-service
     ports:
-      - "${PORT:-8000}:8000"
+    # needs a top level .env for the PORT to take effect here
+      - "${PORT:-8001}:8000"
     env_file:
-      - ./warehouse_managment/warehouse_managment/.env
+      - ./warehouse_managment/.env
     volumes:
       - .:/app
     working_dir: /app/warehouse_managment
     restart: unless-stopped
+    networks:
+      - scms
+
+networks:
+  scms:
+    name: scms-network
+    external : true


### PR DESCRIPTION
This pull request updates the `docker-compose.yaml` file to rename and reconfigure the primary service, adjust environment file paths, and introduce a new external network. These changes aim to improve service clarity and network configuration.

### Service renaming and configuration updates:
* Renamed the service from `django-app` to `warehouse-service` and updated the `container_name` to match the new service name.
* Changed the port mapping to use a default port of `8001` instead of `8000`, with a note indicating the need for a top-level `.env` file for the `PORT` variable.
* Updated the `env_file` path to a more concise location (`./warehouse_managment/.env`).

### Network configuration:
* Added a new external network named `scms-network` and associated the `warehouse-service` with this network.